### PR TITLE
Objectid references

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -49,10 +50,12 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		_, err = tasks.InsertOne(context.TODO(), newTask)
+		result, err := tasks.InsertOne(context.TODO(), newTask)
 		if err != nil {
 			panic(err)
 		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]primitive.ObjectID{"id": result.InsertedID.(primitive.ObjectID)})
 	})
 
 	mux.HandleFunc("GET /tasks", func(w http.ResponseWriter, r *http.Request) {
@@ -73,10 +76,12 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		_, err = teams.InsertOne(context.TODO(), newTeam)
+		result, err := teams.InsertOne(context.TODO(), newTeam)
 		if err != nil {
 			panic(err)
 		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]primitive.ObjectID{"id": result.InsertedID.(primitive.ObjectID)})
 	})
 
 	mux.HandleFunc("GET /teams", func(w http.ResponseWriter, r *http.Request) {
@@ -97,10 +102,12 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		_, err = users.InsertOne(context.TODO(), newUser)
+		result, err := users.InsertOne(context.TODO(), newUser)
 		if err != nil {
 			panic(err)
 		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]primitive.ObjectID{"id": result.InsertedID.(primitive.ObjectID)})
 	})
 
 	mux.HandleFunc("GET /users", func(w http.ResponseWriter, r *http.Request) {

--- a/api/structs.go
+++ b/api/structs.go
@@ -2,13 +2,18 @@ package main
 
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
+type NameIDPair struct {
+  Name string `json:"name"`
+  ID primitive.ObjectID `json:"id"`
+}
+
 /*
 Holds the different teams
 */
 type Team struct {
 	ID    primitive.ObjectID `json:"id" bson:"_id,omitempty"`
 	Name    string   `json:"name"`
-	Members []string `json:"members"`
+	Members []NameIDPair `json:"members"`
 }
 
 /*
@@ -18,8 +23,8 @@ type Task struct {
 	ID    primitive.ObjectID `json:"id" bson:"_id,omitempty"`
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
-	Team string `json:"team"`
-	AssignedTo  []string `json:"assignedTo"`
+	Team NameIDPair `json:"team"`
+	AssignedTo  []NameIDPair `json:"assignedTo"`
 	DueDate primitive.DateTime `json:"dueDate"`
 	Priority    string   `json:"priority"`
 	Status      string   `json:"status"`
@@ -31,9 +36,10 @@ Holds the information of users
 type User struct {
 	ID    primitive.ObjectID `json:"id" bson:"_id,omitempty"`
 	Name  string   `json:"name"`
-	Teams []string `json:"teams"`
+	Teams []NameIDPair `json:"teams"`
 }
 
+/* will need to be updated to work with updated structs
 func getUsers() []User {
 	// create some users
 	user1 := User{
@@ -115,3 +121,4 @@ func getTasks() []Task {
 	tasks = append(tasks, task3)
 	return tasks
 }
+*/


### PR DESCRIPTION
We now store ObjectIDs alongside names when referring to other objects. Additionally, POST requests will respond with the ObjectID of the created object. It will likely be necessary to run `docker volume rm leanto_db-data` to clear the database, since we don't have any way of handling the old records. 